### PR TITLE
[llvm-lto2] Added version command for llvm-lto2

### DIFF
--- a/llvm/test/tools/llvm-lto2/version.test
+++ b/llvm/test/tools/llvm-lto2/version.test
@@ -1,0 +1,7 @@
+## Show that you can run version as a main command for llvm-lto2 
+## or a subcommand of llvm-lto2 run.
+
+RUN: llvm-lto2 version | Filecheck %s
+RUN: llvm-lto2 run --version | FileCheck %s 
+
+CHECK: version

--- a/llvm/test/tools/llvm-lto2/version.test
+++ b/llvm/test/tools/llvm-lto2/version.test
@@ -1,7 +1,7 @@
 ## Show that you can run version as a main command for llvm-lto2 
 ## or a subcommand of llvm-lto2 run.
 
-RUN: llvm-lto2 version | Filecheck %s
+RUN: llvm-lto2 --version | Filecheck %s
 RUN: llvm-lto2 run --version | FileCheck %s 
 
 CHECK: version

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -247,7 +247,7 @@ template <typename T> static T check(ErrorOr<T> E, std::string Msg) {
 }
 
 static int usage() {
-  errs() << "Available subcommands: dump-symtab run print-guid version\n";
+  errs() << "Available subcommands: dump-symtab run print-guid --version\n";
   return 1;
 }
 
@@ -616,7 +616,7 @@ int main(int argc, char **argv) {
     outs() << GlobalValue::getGUIDAssumingExternalLinkage(argv[2]) << '\n';
     return 0;
   }
-  if (Subcommand == "version") {
+  if (Subcommand == "--version") {
     cl::PrintVersionMessage();
     return 0;
   }

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -247,7 +247,7 @@ template <typename T> static T check(ErrorOr<T> E, std::string Msg) {
 }
 
 static int usage() {
-  errs() << "Available subcommands: dump-symtab run print-guid version\n";
+  errs() << "Available subcommands: dump-symtab run print-guid\n";
   return 1;
 }
 

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -247,7 +247,7 @@ template <typename T> static T check(ErrorOr<T> E, std::string Msg) {
 }
 
 static int usage() {
-  errs() << "Available subcommands: dump-symtab run print-guid --version\n";
+  errs() << "Available subcommands: dump-symtab run print-guid version\n";
   return 1;
 }
 

--- a/llvm/tools/llvm-lto2/llvm-lto2.cpp
+++ b/llvm/tools/llvm-lto2/llvm-lto2.cpp
@@ -247,7 +247,7 @@ template <typename T> static T check(ErrorOr<T> E, std::string Msg) {
 }
 
 static int usage() {
-  errs() << "Available subcommands: dump-symtab run print-guid\n";
+  errs() << "Available subcommands: dump-symtab run print-guid version\n";
   return 1;
 }
 
@@ -614,6 +614,10 @@ int main(int argc, char **argv) {
     // Note the name of the function we're calling: this won't return the right
     // answer for internal linkage symbols.
     outs() << GlobalValue::getGUIDAssumingExternalLinkage(argv[2]) << '\n';
+    return 0;
+  }
+  if (Subcommand == "version") {
+    cl::PrintVersionMessage();
     return 0;
   }
   return usage();


### PR DESCRIPTION
Previously, the only way to check version for llvm-lto2 was to add `version` as a subcommand: `llvm-lto2 run --version`. This adds version as a main command for llvm-lto2 for more intuitive access.